### PR TITLE
Add highlight referring elements

### DIFF
--- a/core/apps/ame/src/app/components/editor-canvas/editor-canvas.component.ts
+++ b/core/apps/ame/src/app/components/editor-canvas/editor-canvas.component.ts
@@ -31,6 +31,9 @@ import {EditorService, ShapeSettingsComponent} from '@ame/editor';
 import {ModelService} from '@ame/rdf/services';
 import {FormGroup} from '@angular/forms';
 
+const PURPLE_BLUE = '#448ee4';
+const BLACK = 'black';
+
 @Component({
   selector: 'ame-editor-canvas',
   templateUrl: './editor-canvas.component.html',
@@ -147,7 +150,7 @@ export class EditorCanvasComponent implements AfterViewInit, OnInit, OnDestroy {
 
   onSelectedCell(cells: Array<mxgraph.mxCell>) {
     if (this.shapesToHighlight) {
-      this.setCellStyle('black');
+      this.setCellColor(BLACK);
     }
 
     if (!cells.length || cells.length >= 2) {
@@ -161,13 +164,13 @@ export class EditorCanvasComponent implements AfterViewInit, OnInit, OnDestroy {
       this.shapesToHighlight.push(...this.mxGraphAttributeService.graph.getOutgoingEdges(selectedCell));
       const elementShapes = this.shapesToHighlight.filter(edge => MxGraphHelper.getModelElement(edge.target)).map(edge => edge.target);
       this.shapesToHighlight.push(...elementShapes);
-      this.setCellStyle('#448ee4');
+      this.setCellColor(PURPLE_BLUE);
     }
 
     this.changeDetector.detectChanges();
   }
 
-  private setCellStyle(value: string) {
+  private setCellColor(value: string) {
     this.mxGraphAttributeService.graph.setCellStyles(mxConstants.STYLE_STROKECOLOR, value, this.shapesToHighlight);
   }
 

--- a/core/apps/ame/src/app/components/editor-canvas/editor-canvas.component.ts
+++ b/core/apps/ame/src/app/components/editor-canvas/editor-canvas.component.ts
@@ -17,9 +17,17 @@ import {filter, takeUntil} from 'rxjs/operators';
 import {Subject} from 'rxjs';
 import {mxgraph} from 'mxgraph-factory';
 import {ElementModelService} from '@ame/meta-model';
-import {mxEvent, MxGraphAttributeService, MxGraphHelper, MxGraphService, MxGraphShapeSelectorService, mxUtils} from '@ame/mx-graph';
+import {
+  mxConstants,
+  mxEvent,
+  MxGraphAttributeService,
+  MxGraphHelper,
+  MxGraphService,
+  MxGraphShapeSelectorService,
+  mxUtils,
+} from '@ame/mx-graph';
 import {BindingsService, LogService} from '@ame/shared';
-import {ShapeSettingsComponent, EditorService} from '@ame/editor';
+import {EditorService, ShapeSettingsComponent} from '@ame/editor';
 import {ModelService} from '@ame/rdf/services';
 import {FormGroup} from '@angular/forms';
 
@@ -34,10 +42,9 @@ export class EditorCanvasComponent implements AfterViewInit, OnInit, OnDestroy {
 
   private unsubscribe: Subject<void> = new Subject();
   private selectedShapeForUpdate: mxgraph.mxCell | null;
+  private shapesToHighlight: Array<mxgraph.mxCell> | null;
 
-  public isSidebarOpened = false;
   public isShapeSettingOpened = false;
-  public useDialogModeForEdit = false;
   public modelElement = null;
 
   constructor(
@@ -78,6 +85,10 @@ export class EditorCanvasComponent implements AfterViewInit, OnInit, OnDestroy {
         evt.preventDefault();
       }
     });
+
+    this.mxGraphAttributeService.graph
+      .getSelectionModel()
+      .addListener(mxEvent.CHANGE, selectionModel => this.onSelectedCell(selectionModel.cells));
   }
 
   ngOnInit() {
@@ -132,6 +143,32 @@ export class EditorCanvasComponent implements AfterViewInit, OnInit, OnDestroy {
     this.isShapeSettingOpened = true;
     this.modelElement = MxGraphHelper.getModelElement(this.selectedShapeForUpdate);
     this.changeDetector.detectChanges();
+  }
+
+  onSelectedCell(cells: Array<mxgraph.mxCell>) {
+    if (this.shapesToHighlight) {
+      this.setCellStyle('black');
+    }
+
+    if (!cells.length || cells.length >= 2) {
+      return;
+    }
+
+    this.shapesToHighlight = [];
+    const selectedCell = cells[0];
+
+    if (!selectedCell.isEdge()) {
+      this.shapesToHighlight.push(...this.mxGraphAttributeService.graph.getOutgoingEdges(selectedCell));
+      const elementShapes = this.shapesToHighlight.filter(edge => MxGraphHelper.getModelElement(edge.target)).map(edge => edge.target);
+      this.shapesToHighlight.push(...elementShapes);
+      this.setCellStyle(mxConstants.HIGHLIGHT_COLOR);
+    }
+
+    this.changeDetector.detectChanges();
+  }
+
+  private setCellStyle(value: string) {
+    this.mxGraphAttributeService.graph.setCellStyles(mxConstants.STYLE_STROKECOLOR, value, this.shapesToHighlight);
   }
 
   ngOnDestroy(): void {

--- a/core/apps/ame/src/app/components/editor-canvas/editor-canvas.component.ts
+++ b/core/apps/ame/src/app/components/editor-canvas/editor-canvas.component.ts
@@ -161,7 +161,7 @@ export class EditorCanvasComponent implements AfterViewInit, OnInit, OnDestroy {
       this.shapesToHighlight.push(...this.mxGraphAttributeService.graph.getOutgoingEdges(selectedCell));
       const elementShapes = this.shapesToHighlight.filter(edge => MxGraphHelper.getModelElement(edge.target)).map(edge => edge.target);
       this.shapesToHighlight.push(...elementShapes);
-      this.setCellStyle(mxConstants.HIGHLIGHT_COLOR);
+      this.setCellStyle('#448ee4');
     }
 
     this.changeDetector.detectChanges();

--- a/core/libs/mx-graph/src/lib/services/mx-graph-shape-overlay.service.ts
+++ b/core/libs/mx-graph/src/lib/services/mx-graph-shape-overlay.service.ts
@@ -18,8 +18,8 @@ import {MxGraphHelper, MxGraphVisitorHelper, PropertyInformation} from '../helpe
 import {mxCellOverlay, mxConstants, mxEvent, mxImage} from '../providers';
 import {
   BaseMetaModelElement,
-  DefaultAbstractProperty,
   DefaultAbstractEntity,
+  DefaultAbstractProperty,
   DefaultAspect,
   DefaultCharacteristic,
   DefaultCollection,
@@ -31,8 +31,8 @@ import {
   DefaultOperation,
   DefaultProperty,
   DefaultTrait,
-  OverWrittenProperty,
   DefaultUnit,
+  OverWrittenProperty,
 } from '@ame/meta-model';
 import {BrowserService} from '@ame/shared';
 import {ShapeConnectorService} from '@ame/connection';
@@ -49,7 +49,9 @@ export class MxGraphShapeOverlayService {
   ) {}
 
   public removeOverlay(cell: mxgraph.mxCell, overlay: mxgraph.mxCellOverlay): void {
-    this.mxGraphAttributeService.graph.removeCellOverlay(cell, overlay);
+    if (overlay) {
+      this.mxGraphAttributeService.graph.removeCellOverlay(cell, overlay);
+    }
   }
 
   /**


### PR DESCRIPTION
With large Aspect Models, it is difficult for the user to see which elements are linked to each other. Here the user can select the root element and immediately recognize which underlying elements belong to it.