### PR TITLE
Fix: connection and renaming issues

### DIFF
--- a/core/apps/ame-e2e/src/integration/drag-and-drop/new-elements.cy.ts
+++ b/core/apps/ame-e2e/src/integration/drag-and-drop/new-elements.cy.ts
@@ -36,9 +36,9 @@ describe('Test drag and drop', () => {
 
   it('can add new Trait', () => cy.dragElement(SELECTOR_ecTrait, 350, 300).then(() => cy.clickShape('Trait1')));
 
-  it('can add new Characteristic', () => cy.dragElement(SELECTOR_ecCharacteristic, 350, 300).then(() => cy.clickShape('Characteristic3')));
+  it('can add new Characteristic', () => cy.dragElement(SELECTOR_ecCharacteristic, 350, 300).then(() => cy.clickShape('Characteristic4')));
 
-  it('can add new Constraint', () => cy.dragElement(SELECTOR_ecConstraint, 350, 300).then(() => cy.clickShape('EncodingConstraint1')));
+  it('can add new Constraint', () => cy.dragElement(SELECTOR_ecConstraint, 350, 300).then(() => cy.clickShape('EncodingConstraint2')));
 
   it('can add new Entity', () => cy.dragElement(SELECTOR_ecEntity, 350, 300).then(() => cy.clickShape('Entity1')));
 
@@ -57,17 +57,8 @@ describe('Test drag and drop', () => {
       .then(() => cyHelp.hasAddShapeOverlay('EncodingConstraint1').then(hasAddOverlay => expect(hasAddOverlay).to.equal(false)))
       .then(() => cyHelp.hasAddShapeOverlay('Trait1').then(hasAddOverlay => expect(hasAddOverlay).to.equal(true)))
 
-      .then(() => cy.clickConnectShapes('Trait1', 'EncodingConstraint1'))
-      .then(() => cyHelp.hasAddShapeOverlay('EncodingConstraint1').then(hasAddOverlay => expect(hasAddOverlay).to.equal(false)))
-      .then(() => cyHelp.hasAddShapeOverlay('Trait1').then(hasAddOverlay => expect(hasAddOverlay).to.equal(true)))
-
-      .then(() => cy.clickConnectShapes('Trait1', 'Characteristic1'))
-      .then(() => cyHelp.hasAddShapeOverlay('EncodingConstraint1').then(hasAddOverlay => expect(hasAddOverlay).equal(false)))
-      .then(() => cyHelp.hasAddShapeOverlay('Characteristic1').then(hasAddOverlay => expect(hasAddOverlay).to.equal(true)))
-      .then(() => cyHelp.hasAddShapeOverlay('Trait1').then(hasAddOverlay => expect(hasAddOverlay).to.equal(true)))
-
       .then(() => cy.clickConnectShapes('Characteristic1', 'Entity1'))
-      .then(() => cy.clickConnectShapes('Characteristic4', 'Entity1'))
+      .then(() => cy.clickConnectShapes('Characteristic3', 'Entity1'))
       .then(() => cyHelp.hasAddShapeOverlay('Characteristic1').then(hasAddOverlay => expect(hasAddOverlay).equal(false)))
       .then(() => cyHelp.hasAddShapeOverlay('Entity1').then(hasAddOverlay => expect(hasAddOverlay).to.equal(true)))
 

--- a/core/apps/ame-e2e/src/integration/drag-and-drop/same-namespace/external-constraint-reference.cy.ts
+++ b/core/apps/ame-e2e/src/integration/drag-and-drop/same-namespace/external-constraint-reference.cy.ts
@@ -68,7 +68,6 @@ describe('Test drag and drop ext constraint', () => {
         .then(() => cy.get(SELECTOR_elementBtn).click())
         .then(() => cy.dragElement(SELECTOR_ecTrait, 1100, 300))
         .then(() => cy.clickConnectShapes('property1', 'Trait1'))
-        .then(() => cy.clickConnectShapes('Trait1', 'Characteristic1'))
         .then(() => cy.clickConnectShapes('Trait1', 'ExternalConstraint'))
         .then(() => cyHelp.hasAddShapeOverlay('Trait1').then(hasAddOverlay => expect(hasAddOverlay).equal(true)))
         .then(() => cy.getAspect())
@@ -78,9 +77,9 @@ describe('Test drag and drop ext constraint', () => {
           expect(rdf).to.contain('samm:properties (:property1)');
           expect(rdf).to.contain(':property1 a samm:Property');
           expect(rdf).to.contain('samm:characteristic :Trait1');
-          expect(rdf).to.contain('samm-c:baseCharacteristic :Characteristic1');
-          expect(rdf).to.contain(':Characteristic1 a samm:Characteristic');
-          expect(rdf).to.contain('samm-c:constraint :ExternalConstraint');
+          expect(rdf).to.contain('samm-c:baseCharacteristic :Characteristic2');
+          expect(rdf).to.contain(':Characteristic2 a samm:Characteristic');
+          expect(rdf).to.contain('samm-c:constraint :EncodingConstraint1, :ExternalConstraint');
           expect(rdf).not.contain(':ExternalConstraint a samm:Constraint');
         }),
     );

--- a/core/apps/ame-e2e/src/integration/editor/collapse-expand-model.cy.ts
+++ b/core/apps/ame-e2e/src/integration/editor/collapse-expand-model.cy.ts
@@ -39,7 +39,7 @@ describe('Test collapse/expand model', () => {
         cyHelp.testShapeInExpandMode('property1');
         cyHelp.testShapeInExpandMode('Characteristic1');
         cyHelp.testShapeInExpandMode('Entity1');
-        cyHelp.testShapeInExpandMode('Constraint1');
+        cyHelp.testShapeInExpandMode('EncodingConstraint1');
       });
   });
 

--- a/core/apps/ame-e2e/src/support/utils.ts
+++ b/core/apps/ame-e2e/src/support/utils.ts
@@ -33,8 +33,9 @@ export function checkAspectAndChildrenConstraint(aspect) {
   expect(aspect.properties).to.be.length(1);
   expect(aspect.properties[0].name).to.equal('property1');
   expect(aspect.properties[0].characteristic.name).to.equal('Trait1');
-  expect(aspect.properties[0].characteristic.baseCharacteristic.name).to.equal('Characteristic1');
-  expect(aspect.properties[0].characteristic.constraints[0].name).to.equal('ExternalConstraint');
+  expect(aspect.properties[0].characteristic.baseCharacteristic.name).to.equal('Characteristic2');
+  expect(aspect.properties[0].characteristic.constraints[0].name).to.equal('EncodingConstraint1');
+  expect(aspect.properties[0].characteristic.constraints[1].name).to.equal('ExternalConstraint');
 }
 
 export function checkAspect(aspect) {

--- a/core/libs/aspect-exporter/src/lib/visitor/base-visitor.ts
+++ b/core/libs/aspect-exporter/src/lib/visitor/base-visitor.ts
@@ -30,6 +30,6 @@ export abstract class BaseVisitor<T> {
       file => file.rdfModel.store.getQuads(DataFactory.namedNode(aspectModelUrn), null, null, null).length > 0,
     );
     const alias = externalFile?.rdfModel?.getAliasByDependency(namespace);
-    if (alias) this.loadedFiles.currentLoadedFile.rdfModel.addPrefix(alias, namespace);
+    this.loadedFiles.currentLoadedFile.rdfModel.addPrefix(alias, namespace);
   }
 }

--- a/core/libs/aspect-exporter/src/lib/visitor/characteristic/characteristic-visitor.ts
+++ b/core/libs/aspect-exporter/src/lib/visitor/characteristic/characteristic-visitor.ts
@@ -113,8 +113,6 @@ export class CharacteristicVisitor extends BaseVisitor<DefaultCharacteristic> {
       this.store.getQuads(DataFactory.namedNode(characteristic.aspectModelUrn), this.sammC.ConstraintProperty(), null, null),
     );
 
-    // this.rdfListService.push(characteristic, ...characteristic.constraints);
-
     for (const constraint of characteristic.constraints || []) {
       if (!constraint?.aspectModelUrn) {
         continue;

--- a/core/libs/aspect-exporter/src/lib/visitor/property/property-visitor.ts
+++ b/core/libs/aspect-exporter/src/lib/visitor/property/property-visitor.ts
@@ -33,7 +33,7 @@ export class PropertyVisitor extends BaseVisitor<DefaultProperty> {
   }
 
   visit(property: DefaultProperty): DefaultProperty {
-    if (property.getExtends() || property.isPredefined) {
+    if (property.getExtends() || property.isPredefined || this.loadedFiles.isElementExtern(property)) {
       return null;
     }
 

--- a/core/libs/aspect-model-loader/src/lib/shared/rdf-model.ts
+++ b/core/libs/aspect-model-loader/src/lib/shared/rdf-model.ts
@@ -93,6 +93,41 @@ export class RdfModel {
   }
 
   public addPrefix(alias: string, namespace: string): void {
+    if (alias === '' && !this.prefixes[alias]) {
+      this.prefixes[alias] = namespace;
+      return;
+    }
+
+    const inPrefixes = Object.values(this.prefixes).some(value => value === namespace);
+    if ((alias === '' || alias === undefined) && !inPrefixes) {
+      const matched = namespace.match(/[a-zA-Z]+/gi); //NOSONAR
+      if (matched.length) {
+        let newAlias = `ext-${matched[matched.length - 1]}`;
+        if (this.prefixes[newAlias]) {
+          let count = 2;
+          newAlias = `ext-${matched[matched.length - 1]}${count}`;
+          while (this.prefixes[newAlias]) {
+            count++;
+          }
+        }
+        this.prefixes[newAlias] = namespace;
+        return;
+      }
+    }
+
+    if (inPrefixes) {
+      return;
+    }
+
+    if (this.prefixes[alias]) {
+      let count = 1;
+      while (this.prefixes[`${alias}${count}`]) {
+        count++;
+      }
+      this.prefixes[`${alias}${count}`] = namespace;
+      return;
+    }
+
     this.prefixes[alias] = namespace;
   }
 

--- a/core/libs/connection/src/lib/base-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/base-connection-handler.service.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for
+ * additional information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import {FiltersService} from '@ame/loader-filters';
+import {
+  MxGraphAttributeService,
+  MxGraphHelper,
+  MxGraphRenderer,
+  MxGraphService,
+  MxGraphShapeOverlayService,
+  MxGraphVisitorHelper,
+} from '@ame/mx-graph';
+import {SammLanguageSettingsService} from '@ame/settings-dialog';
+import {ElementCreatorService} from '@ame/shared';
+import {Directive, inject} from '@angular/core';
+import {NamedElement} from '@esmf/aspect-model-loader';
+import {mxgraph} from 'mxgraph-factory';
+
+@Directive()
+export class BaseConnectionHandler {
+  protected readonly sammLangService = inject(SammLanguageSettingsService);
+  protected readonly mxGraphAttributeService = inject(MxGraphAttributeService);
+  protected readonly elementCreator = inject(ElementCreatorService);
+  protected readonly mxGraphService = inject(MxGraphService);
+  protected readonly filtersService = inject(FiltersService);
+  protected mxGraphShapeOverlay = inject(MxGraphShapeOverlayService);
+
+  refreshPropertiesLabel(cell: mxgraph.mxCell, modelElement: NamedElement) {
+    cell['configuration'].fields = MxGraphVisitorHelper.getElementProperties(modelElement, this.sammLangService);
+    this.mxGraphAttributeService.graph.labelChanged(cell, MxGraphHelper.createPropertiesLabel(cell));
+  }
+
+  renderTree(modelElement: NamedElement, parent: mxgraph.mxCell): mxgraph.mxCell {
+    const node = this.filtersService.createNode(modelElement, {parent: MxGraphHelper.getModelElement(parent)});
+    const mxRenderer = new MxGraphRenderer(this.mxGraphService, this.mxGraphShapeOverlay, this.sammLangService, null);
+    return mxRenderer.render(node, parent);
+  }
+}

--- a/core/libs/connection/src/lib/models/inheritance-connector.ts
+++ b/core/libs/connection/src/lib/models/inheritance-connector.ts
@@ -15,18 +15,18 @@ import {MxGraphAttributeService, MxGraphHelper, MxGraphService, MxGraphVisitorHe
 import {SammLanguageSettingsService} from '@ame/settings-dialog';
 import {NotificationsService} from '@ame/shared';
 import {LanguageTranslationService} from '@ame/translation';
+import {inject} from '@angular/core';
 import {DefaultEntity, DefaultProperty, NamedElement} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import mxCell = mxgraph.mxCell;
 
-export abstract class InheritanceConnector {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected notificationsService: NotificationsService,
-    protected translate: LanguageTranslationService,
-  ) {}
+export abstract class InheritanceConnector extends BaseConnectionHandler {
+  protected mxGraphService = inject(MxGraphService);
+  protected mxGraphAttributeService = inject(MxGraphAttributeService);
+  protected sammLangService = inject(SammLanguageSettingsService);
+  protected notificationsService = inject(NotificationsService);
+  protected translate = inject(LanguageTranslationService);
 
   public connect(parentMetaModel: NamedElement, childMetaModel: NamedElement, parentCell: mxCell, childCell: mxCell) {
     if (parentMetaModel?.isPredefined) {

--- a/core/libs/connection/src/lib/models/property-inheritance-connector.ts
+++ b/core/libs/connection/src/lib/models/property-inheritance-connector.ts
@@ -11,26 +11,13 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
-import {NotificationsService} from '@ame/shared';
-import {LanguageTranslationService} from '@ame/translation';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {DefaultEntity, DefaultProperty, NamedElement} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {InheritanceConnector} from './inheritance-connector';
 import mxCell = mxgraph.mxCell;
 
 export class PropertyInheritanceConnector extends InheritanceConnector {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected notificationsService: NotificationsService,
-    protected translate: LanguageTranslationService,
-  ) {
-    super(mxGraphService, mxGraphAttributeService, sammLangService, notificationsService, translate);
-  }
-
   public connect(parentMetaModel: NamedElement, childMetaModel: NamedElement, parentCell: mxCell, childCell: mxCell) {
     if (
       parentMetaModel instanceof DefaultProperty &&

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-entity--abstract-entity.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-entity--abstract-entity.service.ts
@@ -11,12 +11,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {NotificationsService} from '@ame/shared';
-import {LanguageTranslationService} from '@ame/translation';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultEntity} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {EntityInheritanceConnector, MultiShapeConnector} from '../models';
@@ -28,16 +25,7 @@ export class AbstractEntityAbstractEntityConnectionHandler
   extends EntityInheritanceConnector
   implements MultiShapeConnector<DefaultEntity, DefaultEntity>
 {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected filtersService: FiltersService,
-    protected translate: LanguageTranslationService,
-    private notificationService: NotificationsService,
-  ) {
-    super(mxGraphService, mxGraphAttributeService, sammLangService, notificationService, filtersService, translate);
-  }
+  private notificationService = inject(NotificationsService);
 
   public connect(parentMetaModel: DefaultEntity, childMetaModel: DefaultEntity, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (MxGraphHelper.isEntityCycleInheritance(childCell, parentMetaModel, this.mxGraphService.graph)) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-entity--abstract-property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-entity--abstract-property.service.ts
@@ -12,35 +12,28 @@
  */
 
 import {EntityInstanceService} from '@ame/editor';
-import {FiltersService} from '@ame/loader-filters';
-import {MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
-import {DefaultEntity, DefaultProperty} from '@esmf/aspect-model-loader';
+import {MxGraphHelper} from '@ame/mx-graph';
+import {Injectable, inject} from '@angular/core';
+import {DefaultCharacteristic, DefaultEntity, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {MultiShapeConnector} from '../models';
-import {EntityPropertyConnectionHandler} from './entity--property.service';
-import {PropertyAbstractPropertyConnectionHandler} from './property--abstract-property.service';
 
 @Injectable({
   providedIn: 'root',
 })
-export class AbstractEntityAbstractPropertyConnectionHandler implements MultiShapeConnector<DefaultEntity, DefaultProperty> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private entityInstanceService: EntityInstanceService,
-    private propertyAbstractPropertyConnector: PropertyAbstractPropertyConnectionHandler,
-    private entityPropertyConnector: EntityPropertyConnectionHandler,
-    private filtersService: FiltersService,
-  ) {}
+export class AbstractEntityAbstractPropertyConnectionHandler
+  extends BaseConnectionHandler
+  implements MultiShapeConnector<DefaultEntity, DefaultProperty>
+{
+  private entityInstanceService = inject(EntityInstanceService);
 
   public connect(parentMetaModel: DefaultEntity, childMetaModel: DefaultProperty, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (!parentMetaModel.isAbstractEntity() || !childMetaModel.isAbstract) return;
 
     if (!parentMetaModel.properties.find(property => property.aspectModelUrn === childMetaModel.aspectModelUrn)) {
-      const overWrittenProperty = {property: childMetaModel, keys: {}};
-      parentMetaModel.properties.push(overWrittenProperty as any);
-      parentMetaModel.children.push(childMetaModel);
-      this.entityInstanceService.onNewProperty(overWrittenProperty as any, parentMetaModel);
+      parentMetaModel.properties.push(childMetaModel);
+      this.entityInstanceService.onNewProperty(childMetaModel, parentMetaModel);
     }
 
     const grandParents = this.mxGraphService.graph
@@ -65,6 +58,7 @@ export class AbstractEntityAbstractPropertyConnectionHandler implements MultiSha
         aspectModelUrn: `${namespace}#[${name}]`,
         metaModelVersion: childMetaModel.metaModelVersion,
         extends_: childMetaModel,
+        characteristic: this.elementCreator.createEmptyElement(DefaultCharacteristic),
       });
 
       MxGraphHelper.establishRelation(property, childMetaModel);
@@ -73,11 +67,7 @@ export class AbstractEntityAbstractPropertyConnectionHandler implements MultiSha
       grandParentElement.properties.push(property);
       MxGraphHelper.establishRelation(grandParentElement, property);
 
-      const propertyCell = this.mxGraphService.renderModelElement(this.filtersService.createNode(property, {parent: grandParentElement}));
-
-      // connecting the elements
-      this.entityPropertyConnector.connect(grandParentElement, property, grandParent, propertyCell);
-      this.propertyAbstractPropertyConnector.connect(property, childMetaModel, propertyCell, childCell);
+      this.renderTree(property, grandParent);
     }
 
     this.mxGraphService.assignToParent(childCell, parentCell);

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-entity--property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-entity--property.service.ts
@@ -13,7 +13,7 @@
 
 import {EntityInstanceService} from '@ame/editor';
 import {MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {DefaultEntity, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -22,10 +22,8 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class AbstractEntityPropertyConnectionHandler implements MultiShapeConnector<DefaultEntity, DefaultProperty> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private entityInstanceService: EntityInstanceService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
+  private entityInstanceService = inject(EntityInstanceService);
 
   public connect(parentMetaModel: DefaultEntity, childMetaModel: DefaultProperty, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (!parentMetaModel.isAbstractEntity()) return;

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-property--abstract-property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/abstract-property--abstract-property.service.ts
@@ -11,11 +11,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {NotificationsService} from '@ame/shared';
-import {LanguageTranslationService} from '@ame/translation';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector, PropertyInheritanceConnector} from '../models';
@@ -27,15 +25,7 @@ export class AbstractPropertyAbstractPropertyConnectionHandler
   extends PropertyInheritanceConnector
   implements MultiShapeConnector<DefaultProperty, DefaultProperty>
 {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected translate: LanguageTranslationService,
-    private notificationService: NotificationsService,
-  ) {
-    super(mxGraphService, mxGraphAttributeService, sammLangService, notificationService, translate);
-  }
+  private notificationService = inject(NotificationsService);
 
   public connect(parentMetaModel: DefaultProperty, childMetaModel: DefaultProperty, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (!parentMetaModel.isAbstract || !childMetaModel.isAbstract) return;

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/aspect--event.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/aspect--event.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {DefaultAspect, DefaultEvent} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,7 +21,7 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class AspectEventConnectionHandler implements MultiShapeConnector<DefaultAspect, DefaultEvent> {
-  constructor(private mxGraphService: MxGraphService) {}
+  private mxGraphService = inject(MxGraphService);
 
   public connect(parentMetaModel: DefaultAspect, childMetaModel: DefaultEvent, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     if (!parentMetaModel.events.find(operation => operation.aspectModelUrn === childMetaModel.aspectModelUrn)) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/aspect--property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/aspect--property.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {DefaultAspect, DefaultOperation, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,7 +21,7 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class AspectPropertyConnectionHandler implements MultiShapeConnector<DefaultAspect, DefaultProperty | DefaultOperation> {
-  constructor(private mxGraphService: MxGraphService) {}
+  private mxGraphService = inject(MxGraphService);
 
   public connect(
     parentMetaModel: DefaultAspect,

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/characteristic--entity.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/characteristic--entity.service.ts
@@ -15,7 +15,7 @@ import {LoadedFilesService} from '@ame/cache';
 import {MxGraphAttributeService, MxGraphHelper, MxGraphService, MxGraphShapeOverlayService} from '@ame/mx-graph';
 import {SammLanguageSettingsService} from '@ame/settings-dialog';
 import {NotificationsService} from '@ame/shared';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {
   DefaultCharacteristic,
   DefaultEntity,
@@ -32,18 +32,16 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class CharacteristicEntityConnectionHandler implements MultiShapeConnector<DefaultCharacteristic, DefaultEntity> {
+  private mxGraphService = inject(MxGraphService);
+  private mxGraphAttributeService = inject(MxGraphAttributeService);
+  private mxGraphShapeOverlayService = inject(MxGraphShapeOverlayService);
+  private sammLangService = inject(SammLanguageSettingsService);
+  private notificationsService = inject(NotificationsService);
+  private loadedFiles = inject(LoadedFilesService);
+
   get currentCachedFile() {
     return this.loadedFiles.currentLoadedFile.cachedFile;
   }
-
-  constructor(
-    private mxGraphService: MxGraphService,
-    private mxGraphAttributeService: MxGraphAttributeService,
-    private mxGraphShapeOverlayService: MxGraphShapeOverlayService,
-    private sammLangService: SammLanguageSettingsService,
-    private notificationsService: NotificationsService,
-    private loadedFiles: LoadedFilesService,
-  ) {}
 
   connect(parentMetaModel: DefaultCharacteristic, childMetaModel: DefaultEntity, parent: mxgraph.mxCell, child: mxgraph.mxCell): void {
     if (parentMetaModel instanceof DefaultStructuredValue) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/characteristic--unit.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/characteristic--unit.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultCharacteristic, DefaultQuantifiable, DefaultUnit} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,7 +21,7 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class CharacteristicUnitConnectionHandler implements MultiShapeConnector<DefaultCharacteristic, DefaultUnit> {
-  constructor(private mxGraphService: MxGraphService) {}
+  private mxGraphService = inject(MxGraphService);
 
   public connect(parentMetaModel: DefaultCharacteristic, childMetaModel: DefaultUnit, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     if (!(parentMetaModel instanceof DefaultQuantifiable)) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/collection--characteristic.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/collection--characteristic.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultCharacteristic, DefaultCollection, DefaultEntity} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,10 +21,8 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class CollectionCharacteristicConnectionHandler implements MultiShapeConnector<DefaultCollection, DefaultCharacteristic> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private mxGraphAttributeService: MxGraphAttributeService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
+  private mxGraphAttributeService = inject(MxGraphAttributeService);
 
   public connect(parentMetaModel: DefaultCollection, childMetaModel: DefaultCharacteristic, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     this.mxGraphAttributeService.graph.getOutgoingEdges(parent).forEach(outEdge => {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/either--left-characteristic.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/either--left-characteristic.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultCharacteristic, DefaultEither} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,10 +21,8 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class EitherCharacteristicLeftConnectionHandler implements MultiShapeConnector<DefaultEither, DefaultCharacteristic> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private mxGraphAttributeService: MxGraphAttributeService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
+  private mxGraphAttributeService = inject(MxGraphAttributeService);
 
   public connect(parentMetaModel: DefaultEither, childMetaModel: DefaultCharacteristic, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     parentMetaModel.left = childMetaModel;

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/either--right-characteristic.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/either--right-characteristic.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultCharacteristic, DefaultEither} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,10 +21,8 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class EitherCharacteristicRightConnectionHandler implements MultiShapeConnector<DefaultEither, DefaultCharacteristic> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private mxGraphAttributeService: MxGraphAttributeService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
+  private mxGraphAttributeService = inject(MxGraphAttributeService);
 
   public connect(parentMetaModel: DefaultEither, childMetaModel: DefaultCharacteristic, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     parentMetaModel.right = childMetaModel;

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/entity--abstract-entity.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/entity--abstract-entity.service.ts
@@ -11,17 +11,12 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {NotificationsService} from '@ame/shared';
-import {LanguageTranslationService} from '@ame/translation';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultEntity} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {EntityInheritanceConnector, MultiShapeConnector} from '../models';
-import {EntityPropertyConnectionHandler} from './entity--property.service';
-import {PropertyAbstractPropertyConnectionHandler} from './property--abstract-property.service';
 
 @Injectable({
   providedIn: 'root',
@@ -30,27 +25,7 @@ export class EntityAbstractEntityConnectionHandler
   extends EntityInheritanceConnector
   implements MultiShapeConnector<DefaultEntity, DefaultEntity>
 {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected propertyAbstractPropertyConnector: PropertyAbstractPropertyConnectionHandler,
-    protected entityPropertyConnector: EntityPropertyConnectionHandler,
-    protected filtersService: FiltersService,
-    protected translate: LanguageTranslationService,
-    private notificationService: NotificationsService,
-  ) {
-    super(
-      mxGraphService,
-      mxGraphAttributeService,
-      sammLangService,
-      notificationService,
-      filtersService,
-      translate,
-      propertyAbstractPropertyConnector,
-      entityPropertyConnector,
-    );
-  }
+  private notificationService = inject(NotificationsService);
 
   public connect(parentMetaModel: DefaultEntity, childMetaModel: DefaultEntity, parent: mxgraph.mxCell, child: mxgraph.mxCell): void {
     if (MxGraphHelper.isEntityCycleInheritance(child, parentMetaModel, this.mxGraphService.graph)) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/entity--entity.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/entity--entity.service.ts
@@ -11,43 +11,18 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {NotificationsService} from '@ame/shared';
-import {LanguageTranslationService} from '@ame/translation';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultEntity} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {EntityInheritanceConnector, MultiShapeConnector} from '../models';
-import {EntityPropertyConnectionHandler} from './entity--property.service';
-import {PropertyAbstractPropertyConnectionHandler} from './property--abstract-property.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class EntityEntityConnectionHandler extends EntityInheritanceConnector implements MultiShapeConnector<DefaultEntity, DefaultEntity> {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected propertyAbstractPropertyConnector: PropertyAbstractPropertyConnectionHandler,
-    protected entityPropertyConnector: EntityPropertyConnectionHandler,
-    protected filtersService: FiltersService,
-    protected translate: LanguageTranslationService,
-    private notificationService: NotificationsService,
-  ) {
-    super(
-      mxGraphService,
-      mxGraphAttributeService,
-      sammLangService,
-      notificationService,
-      filtersService,
-      translate,
-      propertyAbstractPropertyConnector,
-      entityPropertyConnector,
-    );
-  }
+  private notificationService = inject(NotificationsService);
 
   public connect(parentMetaModel: DefaultEntity, childMetaModel: DefaultEntity, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (MxGraphHelper.isEntityCycleInheritance(childCell, parentMetaModel, this.mxGraphService.graph)) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/entity--property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/entity--property.service.ts
@@ -13,7 +13,7 @@
 
 import {EntityInstanceService} from '@ame/editor';
 import {MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {DefaultEntity, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -22,10 +22,8 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class EntityPropertyConnectionHandler implements MultiShapeConnector<DefaultEntity, DefaultProperty> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private entityInstanceService: EntityInstanceService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
+  private entityInstanceService = inject(EntityInstanceService);
 
   public connect(parentMetaModel: DefaultEntity, childMetaModel: DefaultProperty, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (!parentMetaModel.properties.find(property => property.aspectModelUrn === childMetaModel.aspectModelUrn)) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/enumeration--entity-value.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/enumeration--entity-value.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultEntityInstance, DefaultEnumeration} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,7 +21,7 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class EnumerationEntityValueConnectionHandler implements MultiShapeConnector<DefaultEnumeration, DefaultEntityInstance> {
-  constructor(private mxGraphService: MxGraphService) {}
+  private mxGraphService = inject(MxGraphService);
 
   connect(parentMetaModel: DefaultEnumeration, childMetaModel: DefaultEntityInstance, parent: mxgraph.mxCell, child: mxgraph.mxCell): void {
     childMetaModel.addParent(parentMetaModel);

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/event--property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/event--property.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {DefaultEvent, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -21,7 +21,7 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class EventPropertyConnectionHandler implements MultiShapeConnector<DefaultEvent, DefaultProperty> {
-  constructor(private mxGraphService: MxGraphService) {}
+  private mxGraphService = inject(MxGraphService);
 
   public connect(parentMetaModel: DefaultEvent, childMetaModel: DefaultProperty, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     if (!parentMetaModel.properties.find(param => param.aspectModelUrn === childMetaModel.aspectModelUrn)) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/operation--input-property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/operation--input-property.service.ts
@@ -12,7 +12,7 @@
  */
 
 import {MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {DefaultOperation, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnectorWithProperty} from '../models';
@@ -21,7 +21,7 @@ import {MultiShapeConnectorWithProperty} from '../models';
   providedIn: 'root',
 })
 export class OperationPropertyInputConnectionHandler implements MultiShapeConnectorWithProperty<DefaultOperation, DefaultProperty> {
-  constructor(private mxGraphService: MxGraphService) {}
+  private mxGraphService = inject(MxGraphService);
 
   public connect(parentMetaModel: DefaultOperation, childMetaModel: DefaultProperty, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     const isInputAlreadyDefined = parentMetaModel.input.some(value => value.aspectModelUrn === childMetaModel.aspectModelUrn);

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/operation--output-property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/operation--output-property.service.ts
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {MxGraphAttributeService, MxGraphService} from '@ame/mx-graph';
-import {Injectable} from '@angular/core';
+import {MxGraphService} from '@ame/mx-graph';
+import {Injectable, inject} from '@angular/core';
 import {DefaultOperation, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnectorWithProperty} from '../models';
@@ -21,10 +21,7 @@ import {MultiShapeConnectorWithProperty} from '../models';
   providedIn: 'root',
 })
 export class OperationPropertyOutputConnectionHandler implements MultiShapeConnectorWithProperty<DefaultOperation, DefaultProperty> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private mxGraphAttributeService: MxGraphAttributeService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
 
   public connect(parentMetaModel: DefaultOperation, childMetaModel: DefaultProperty, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     parentMetaModel.output = childMetaModel;

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/property--abstract-property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/property--abstract-property.service.ts
@@ -11,11 +11,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {NotificationsService} from '@ame/shared';
-import {LanguageTranslationService} from '@ame/translation';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector, PropertyInheritanceConnector} from '../models';
@@ -27,15 +25,7 @@ export class PropertyAbstractPropertyConnectionHandler
   extends PropertyInheritanceConnector
   implements MultiShapeConnector<DefaultProperty, DefaultProperty>
 {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected translate: LanguageTranslationService,
-    private notificationService: NotificationsService,
-  ) {
-    super(mxGraphService, mxGraphAttributeService, sammLangService, notificationService, translate);
-  }
+  private notificationService = inject(NotificationsService);
 
   public connect(parentMetaModel: DefaultProperty, childMetaModel: DefaultProperty, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (!childMetaModel.isAbstract) return;

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/property--characteristic.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/property--characteristic.service.ts
@@ -13,7 +13,7 @@
 
 import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
 import {basicShapeGeometry} from '@ame/shared';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultCharacteristic, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -22,10 +22,8 @@ import {MultiShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class PropertyCharacteristicConnectionHandler implements MultiShapeConnector<DefaultProperty, DefaultCharacteristic> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private mxGraphAttributeService: MxGraphAttributeService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
+  private mxGraphAttributeService = inject(MxGraphAttributeService);
 
   public connect(parentMetaModel: DefaultProperty, childMetaModel: DefaultCharacteristic, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
     this.mxGraphAttributeService.graph.getOutgoingEdges(parent).forEach((outEdge: mxgraph.mxCell) => {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/property--property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/property--property.service.ts
@@ -11,11 +11,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {NotificationsService} from '@ame/shared';
-import {LanguageTranslationService} from '@ame/translation';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector, PropertyInheritanceConnector} from '../models';
@@ -27,15 +25,7 @@ export class PropertyPropertyConnectionHandler
   extends PropertyInheritanceConnector
   implements MultiShapeConnector<DefaultProperty, DefaultProperty>
 {
-  constructor(
-    protected mxGraphService: MxGraphService,
-    protected mxGraphAttributeService: MxGraphAttributeService,
-    protected sammLangService: SammLanguageSettingsService,
-    protected translate: LanguageTranslationService,
-    private notificationService: NotificationsService,
-  ) {
-    super(mxGraphService, mxGraphAttributeService, sammLangService, notificationService, translate);
-  }
+  private notificationService = inject(NotificationsService);
 
   public connect(parentMetaModel: DefaultProperty, childMetaModel: DefaultProperty, parentCell: mxgraph.mxCell, childCell: mxgraph.mxCell) {
     if (parentMetaModel.isPredefined) {

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/property--structured-value.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/property--structured-value.service.ts
@@ -13,7 +13,7 @@
 
 import {MxGraphHelper} from '@ame/mx-graph';
 import {NotificationsService} from '@ame/shared';
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {DefaultProperty, DefaultStructuredValue} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -23,10 +23,8 @@ import {PropertyCharacteristicConnectionHandler} from './property--characteristi
   providedIn: 'root',
 })
 export class PropertyStructuredValueConnectionHandler implements MultiShapeConnector<DefaultProperty, DefaultStructuredValue> {
-  constructor(
-    private notificationsService: NotificationsService,
-    private propertyCharacteristicConnectionHandler: PropertyCharacteristicConnectionHandler,
-  ) {}
+  private notificationsService = inject(NotificationsService);
+  private propertyCharacteristicConnectionHandler = inject(PropertyCharacteristicConnectionHandler);
 
   connect(parentMetaModel: DefaultProperty, childMetaModel: DefaultStructuredValue, parent: mxgraph.mxCell, child: mxgraph.mxCell): void {
     const isRecursiveConnection = MxGraphHelper.isChildOf(childMetaModel, parentMetaModel);

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/structured-value--property.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/structured-value--property.service.ts
@@ -14,7 +14,7 @@
 import {MxGraphAttributeService, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
 import {SammLanguageSettingsService} from '@ame/settings-dialog';
 import {NotificationsService} from '@ame/shared';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultProperty, DefaultStructuredValue} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {MultiShapeConnector} from '../models';
@@ -25,12 +25,10 @@ import {MultiShapeConnector} from '../models';
 export class StructuredValueCharacteristicPropertyConnectionHandler
   implements MultiShapeConnector<DefaultStructuredValue, DefaultProperty>
 {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private mxGraphAttributeService: MxGraphAttributeService,
-    private sammLangService: SammLanguageSettingsService,
-    private notificationsService: NotificationsService,
-  ) {}
+  private mxGraphService = inject(MxGraphService);
+  private mxGraphAttributeService = inject(MxGraphAttributeService);
+  private sammLangService = inject(SammLanguageSettingsService);
+  private notificationsService = inject(NotificationsService);
 
   connect(parentMetaModel: DefaultStructuredValue, childMetaModel: DefaultProperty, first: mxgraph.mxCell, second: mxgraph.mxCell): void {
     const isRecursiveConnection = MxGraphHelper.isChildOf(childMetaModel, parentMetaModel);

--- a/core/libs/connection/src/lib/multi-shape-connection-handlers/trait--characteristic--constraint.service.ts
+++ b/core/libs/connection/src/lib/multi-shape-connection-handlers/trait--characteristic--constraint.service.ts
@@ -26,7 +26,9 @@ export class TraitWithCharacteristicOrConstraintConnectionHandler
   constructor(private mxGraphService: MxGraphService) {}
 
   public connect(parentMetaModel: DefaultTrait, childMetaModel: DefaultCharacteristic, parent: mxgraph.mxCell, child: mxgraph.mxCell) {
-    parentMetaModel.baseCharacteristic = childMetaModel;
+    if (childMetaModel instanceof DefaultConstraint) {
+      parentMetaModel.constraints.push(childMetaModel);
+    } else parentMetaModel.baseCharacteristic = childMetaModel;
     this.mxGraphService.assignToParent(child, parent);
   }
 }

--- a/core/libs/connection/src/lib/single-connection-handlers/aspect-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/aspect-connection-handler.service.ts
@@ -11,31 +11,25 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {MxGraphService} from '@ame/mx-graph';
-import {ElementCreatorService} from '@ame/shared';
 import {Injectable} from '@angular/core';
 import {Aspect, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {SingleShapeConnector} from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class AspectConnectionHandler implements SingleShapeConnector<Aspect> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private filtersService: FiltersService,
-    private elementCreator: ElementCreatorService,
-  ) {}
+export class AspectConnectionHandler extends BaseConnectionHandler implements SingleShapeConnector<Aspect> {
+  constructor() {
+    super();
+  }
 
   public connect(aspect: Aspect, source: mxgraph.mxCell) {
     const defaultProperty = this.elementCreator.createEmptyElement(DefaultProperty);
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(defaultProperty);
-    const child = this.mxGraphService.renderModelElement(this.filtersService.createNode(metaModelElement, {parent: aspect}));
+    const child = this.renderTree(defaultProperty, source);
     aspect.properties.push(defaultProperty);
+
     this.mxGraphService.assignToParent(child, source);
     this.mxGraphService.formatCell(source);
     this.mxGraphService.formatShapes();

--- a/core/libs/connection/src/lib/single-connection-handlers/constraint-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/constraint-connection-handler.service.ts
@@ -11,13 +11,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {ElementCreatorService} from '@ame/shared';
-import {useUpdater} from '@ame/utils';
 import {Injectable} from '@angular/core';
-import {DefaultCharacteristic, DefaultConstraint} from '@esmf/aspect-model-loader';
+import {DefaultConstraint} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
 import {SingleShapeConnector} from '../models';
 
@@ -25,22 +20,10 @@ import {SingleShapeConnector} from '../models';
   providedIn: 'root',
 })
 export class ConstraintConnectionHandler implements SingleShapeConnector<DefaultConstraint> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private filtersService: FiltersService,
-    private elementCreator: ElementCreatorService,
-  ) {}
+  constructor() {}
 
-  public connect(constraint: DefaultConstraint, source: mxgraph.mxCell) {
-    const defaultCharacteristic = this.elementCreator.createEmptyElement(DefaultCharacteristic);
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(defaultCharacteristic);
-    const child = this.mxGraphService.renderModelElement(
-      this.filtersService.createNode(metaModelElement, {parent: MxGraphHelper.getModelElement(source)}),
-    );
-    useUpdater(constraint).update(defaultCharacteristic);
-    this.mxGraphService.assignToParent(child, source);
-    this.mxGraphService.formatCell(source);
-    this.mxGraphService.formatShapes();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public connect(_constraint: DefaultConstraint, _source: mxgraph.mxCell) {
+    // This method is intentionally left empty as any type of constraint - child connection is not allowed
   }
 }

--- a/core/libs/connection/src/lib/single-connection-handlers/either-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/either-connection-handler.service.ts
@@ -11,26 +11,21 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {ModelInfo, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {ElementCreatorService, NotificationsService} from '@ame/shared';
+import {ModelInfo} from '@ame/mx-graph';
+import {NotificationsService} from '@ame/shared';
 import {Injectable} from '@angular/core';
 import {DefaultCharacteristic, DefaultEither} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {SingleShapeConnector} from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class EitherConnectionHandler implements SingleShapeConnector<DefaultEither> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private notificationsService: NotificationsService,
-    private filtersService: FiltersService,
-    private elementCreator: ElementCreatorService,
-  ) {}
+export class EitherConnectionHandler extends BaseConnectionHandler implements SingleShapeConnector<DefaultEither> {
+  constructor(private notificationsService: NotificationsService) {
+    super();
+  }
 
   public connect(either: DefaultEither, source: mxgraph.mxCell, modelInfo: ModelInfo) {
     const defaultCharacteristic = this.elementCreator.createEmptyElement(DefaultCharacteristic);
@@ -49,10 +44,8 @@ export class EitherConnectionHandler implements SingleShapeConnector<DefaultEith
       either.right = defaultCharacteristic;
     }
 
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(defaultCharacteristic);
-    const child = this.mxGraphService.renderModelElement(
-      this.filtersService.createNode(metaModelElement, {parent: MxGraphHelper.getModelElement(source)}),
-    );
+    const child = this.renderTree(defaultCharacteristic, source);
+    this.refreshPropertiesLabel(child, defaultCharacteristic);
     this.mxGraphService.assignToParent(child, source);
     this.mxGraphService.formatCell(source);
     this.mxGraphService.formatShapes();

--- a/core/libs/connection/src/lib/single-connection-handlers/entity-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/entity-connection-handler.service.ts
@@ -12,36 +12,27 @@
  */
 
 import {EntityInstanceService} from '@ame/editor';
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {MxGraphHelper, MxGraphRenderer, MxGraphService, MxGraphShapeOverlayService} from '@ame/mx-graph';
-import {SammLanguageSettingsService} from '@ame/settings-dialog';
-import {ElementCreatorService} from '@ame/shared';
-import {Injectable, inject} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {DefaultProperty, Entity} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {SingleShapeConnector} from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class EntityConnectionHandler implements SingleShapeConnector<Entity> {
-  private mxGraphShapeOverlay = inject(MxGraphShapeOverlayService);
-  private sammLangService = inject(SammLanguageSettingsService);
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private entityInstanceService: EntityInstanceService,
-    private filtersService: FiltersService,
-    private elementCreator: ElementCreatorService,
-  ) {}
+export class EntityConnectionHandler extends BaseConnectionHandler implements SingleShapeConnector<Entity> {
+  constructor(private entityInstanceService: EntityInstanceService) {
+    super();
+  }
 
   public connect(entity: Entity, source: mxgraph.mxCell) {
     const defaultProperty = this.elementCreator.createEmptyElement(DefaultProperty);
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(defaultProperty);
-    const mxRenderer = new MxGraphRenderer(this.mxGraphService, this.mxGraphShapeOverlay, this.sammLangService, null);
-    mxRenderer.render(this.filtersService.createNode(metaModelElement, {parent: MxGraphHelper.getModelElement(source)}), source);
+    const child = this.renderTree(defaultProperty, source);
+    this.refreshPropertiesLabel(child, defaultProperty);
+
     entity.properties.push(defaultProperty);
+    this.mxGraphService.assignToParent(child, source);
     this.entityInstanceService.onNewProperty(defaultProperty, entity);
     this.mxGraphService.formatCell(source, true);
   }

--- a/core/libs/connection/src/lib/single-connection-handlers/event-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/event-connection-handler.service.ts
@@ -11,32 +11,21 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {ElementCreatorService} from '@ame/shared';
 import {Injectable} from '@angular/core';
 import {DefaultEvent, DefaultProperty} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {SingleShapeConnector} from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class EventConnectionHandler implements SingleShapeConnector<DefaultEvent> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private filtersService: FiltersService,
-    private elementCreator: ElementCreatorService,
-  ) {}
-
+export class EventConnectionHandler extends BaseConnectionHandler implements SingleShapeConnector<DefaultEvent> {
   public connect(event: DefaultEvent, source: mxgraph.mxCell) {
     const defaultProperty = this.elementCreator.createEmptyElement(DefaultProperty);
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(defaultProperty);
-    const child = this.mxGraphService.renderModelElement(
-      this.filtersService.createNode(metaModelElement, {parent: MxGraphHelper.getModelElement(source)}),
-    );
+    const child = this.renderTree(defaultProperty, source);
+    this.refreshPropertiesLabel(child, defaultProperty);
+
     event.properties.push(defaultProperty);
     this.mxGraphService.assignToParent(child, source);
     this.mxGraphService.formatCell(source);

--- a/core/libs/connection/src/lib/single-connection-handlers/operation-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/operation-connection-handler.service.ts
@@ -11,26 +11,21 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {ModelInfo, MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {ElementCreatorService, NotificationsService} from '@ame/shared';
+import {ModelInfo} from '@ame/mx-graph';
+import {NotificationsService} from '@ame/shared';
 import {Injectable} from '@angular/core';
 import {DefaultProperty, Operation} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {SingleShapeConnector} from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class OperationConnectionHandler implements SingleShapeConnector<Operation> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private notificationsService: NotificationsService,
-    private filtersService: FiltersService,
-    private elementCreator: ElementCreatorService,
-  ) {}
+export class OperationConnectionHandler extends BaseConnectionHandler implements SingleShapeConnector<Operation> {
+  constructor(private notificationsService: NotificationsService) {
+    super();
+  }
 
   public connect(operation: Operation, source: mxgraph.mxCell, modelInfo: ModelInfo) {
     const defaultProperty = this.elementCreator.createEmptyElement(DefaultProperty);
@@ -45,10 +40,8 @@ export class OperationConnectionHandler implements SingleShapeConnector<Operatio
       operation.input.push(defaultProperty);
     }
 
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(defaultProperty);
-    const child = this.mxGraphService.renderModelElement(
-      this.filtersService.createNode(metaModelElement, {parent: MxGraphHelper.getModelElement(source)}),
-    );
+    const child = this.renderTree(defaultProperty, source);
+    this.refreshPropertiesLabel(child, defaultProperty);
     this.mxGraphService.assignToParent(child, source);
     this.mxGraphService.formatCell(source);
     this.mxGraphService.formatShapes();

--- a/core/libs/connection/src/lib/single-connection-handlers/structured-value-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/structured-value-connection-handler.service.ts
@@ -12,41 +12,30 @@
  */
 
 import {LoadedFilesService} from '@ame/cache';
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {ElementCreatorService} from '@ame/shared';
-import {Injectable} from '@angular/core';
+import {Injectable, inject} from '@angular/core';
 import {DefaultProperty, StructuredValue} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {SingleShapeConnector} from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class StructuredValueConnectionHandler implements SingleShapeConnector<StructuredValue> {
+export class StructuredValueConnectionHandler extends BaseConnectionHandler implements SingleShapeConnector<StructuredValue> {
+  private loadedFiles = inject(LoadedFilesService);
+
   get currentCachedFile() {
     return this.loadedFiles.currentLoadedFile.cachedFile;
   }
-
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private filtersService: FiltersService,
-    private loadedFiles: LoadedFilesService,
-    private elementCreator: ElementCreatorService,
-  ) {}
 
   public connect(structuredValue: StructuredValue, source: mxgraph.mxCell) {
     const property = this.elementCreator.createEmptyElement(DefaultProperty);
     structuredValue.elements.push(property);
     structuredValue.deconstructionRule = `${structuredValue.deconstructionRule}(regex)`;
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(property);
-    const propertyCell = this.mxGraphService.renderModelElement(
-      this.filtersService.createNode(metaModelElement, {parent: MxGraphHelper.getModelElement(source)}),
-    );
-    this.mxGraphService.graph.labelChanged(source, MxGraphHelper.createPropertiesLabel(source));
-    this.mxGraphService.assignToParent(propertyCell, source);
+    const child = this.renderTree(property, source);
+
+    this.refreshPropertiesLabel(child, property);
+    this.mxGraphService.assignToParent(child, source);
     this.currentCachedFile.resolveInstance(property);
 
     this.mxGraphService.formatCell(source);

--- a/core/libs/connection/src/lib/single-connection-handlers/trait-connection-handler.service.ts
+++ b/core/libs/connection/src/lib/single-connection-handlers/trait-connection-handler.service.ts
@@ -11,38 +11,34 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import {FiltersService} from '@ame/loader-filters';
-import {ModelElementNamingService} from '@ame/meta-model';
-import {MxGraphHelper, MxGraphService} from '@ame/mx-graph';
-import {ElementCreatorService} from '@ame/shared';
+import {MxGraphHelper} from '@ame/mx-graph';
 import {useUpdater} from '@ame/utils';
 import {Injectable} from '@angular/core';
 import {DefaultCharacteristic, DefaultConstraint, DefaultTrait} from '@esmf/aspect-model-loader';
 import {mxgraph} from 'mxgraph-factory';
+import {BaseConnectionHandler} from '../base-connection-handler.service';
 import {SingleShapeConnector} from '../models';
 
 @Injectable({
   providedIn: 'root',
 })
-export class TraitConnectionHandler implements SingleShapeConnector<DefaultTrait> {
-  constructor(
-    private mxGraphService: MxGraphService,
-    private modelElementNamingService: ModelElementNamingService,
-    private filtersService: FiltersService,
-    private elementCreator: ElementCreatorService,
-  ) {}
+export class TraitConnectionHandler extends BaseConnectionHandler implements SingleShapeConnector<DefaultTrait> {
+  constructor() {
+    super();
+  }
 
   public connect(trait: DefaultTrait, source: mxgraph.mxCell) {
     const defaultElement =
       trait.getBaseCharacteristic() == null
         ? this.elementCreator.createEmptyElement(DefaultCharacteristic)
         : this.elementCreator.createEmptyElement(DefaultConstraint);
-    const metaModelElement = this.modelElementNamingService.resolveMetaModelElement(defaultElement);
     const child = this.mxGraphService.renderModelElement(
-      this.filtersService.createNode(metaModelElement, {parent: MxGraphHelper.getModelElement(source)}),
+      this.filtersService.createNode(defaultElement, {parent: MxGraphHelper.getModelElement(source)}),
     );
 
     useUpdater(trait).update(defaultElement);
+    this.refreshPropertiesLabel(child, defaultElement);
+
     this.mxGraphService.assignToParent(child, source);
     this.mxGraphService.moveCells([child], source.getGeometry().x + 30, source.getGeometry().y + 60);
     this.mxGraphService.formatCell(child);

--- a/core/libs/instantiator/src/lib/instantiator.service.ts
+++ b/core/libs/instantiator/src/lib/instantiator.service.ts
@@ -59,7 +59,7 @@ export class InstantiatorService {
     }
 
     if (elementType.endsWith('Constraint')) {
-      return createConstraint(new Triple(new NamedNode(subject), null, null));
+      return createConstraint(new Triple(new NamedNode(subject), null, new NamedNode(subject)));
     }
 
     if (sammC.isStandardCharacteristic(elementType) || samm.Characteristic().value === elementType) {

--- a/core/libs/loader-filters/src/lib/filters.service.ts
+++ b/core/libs/loader-filters/src/lib/filters.service.ts
@@ -83,7 +83,9 @@ export class FiltersService {
   }
 
   updateNodeTree<T extends NamedElement = NamedElement>(node: ModelTree<T>, options?: ModelTreeOptions): ModelTree<T> {
-    return this.currentFilter.generateTree(node.element, options);
+    const generatedNode = this.currentFilter.generateTree(node.element, options);
+    this.currentFilter.cache = {};
+    return generatedNode;
   }
 
   renderByFilter(filter: ModelFilter) {

--- a/core/libs/meta-model/src/lib/element-service/element-model.service.ts
+++ b/core/libs/meta-model/src/lib/element-service/element-model.service.ts
@@ -91,7 +91,7 @@ export class ElementModelService {
     }
 
     const elementModel = MxGraphHelper.getModelElement(cell);
-    if (this.modelRootService.isPredefined(elementModel)) {
+    if (elementModel.isPredefined) {
       const service = this.modelRootService.getPredefinedService(elementModel);
       if (service?.delete && service?.delete?.(cell)) {
         return;

--- a/core/libs/meta-model/src/lib/services/model-element-naming.service.ts
+++ b/core/libs/meta-model/src/lib/services/model-element-naming.service.ts
@@ -46,14 +46,14 @@ export class ModelElementNamingService {
    * @returns element with filled version,name,urn
    */
   resolveElementNaming<T extends NamedElement = NamedElement>(element: T, parentName?: string): T {
-    const rdfModel = this.loadedFiles.currentLoadedFile.rdfModel;
+    const {rdfModel, namespace} = this.loadedFiles.currentLoadedFile;
     const elements = {};
 
     if (!rdfModel) {
       return null;
     }
 
-    const mainAspectModelUrn = rdfModel.getAspectModelUrn();
+    const mainAspectModelUrn = `urn:samm:${namespace}#`;
     for (const extRdfModel of this.loadedFiles.externalFiles.map(f => f.rdfModel)) {
       if (!Object.values(extRdfModel.getPrefixes()).includes(mainAspectModelUrn)) {
         continue;

--- a/core/libs/mx-graph/src/lib/services/mx-graph-shape-selector.service.ts
+++ b/core/libs/mx-graph/src/lib/services/mx-graph-shape-selector.service.ts
@@ -48,6 +48,9 @@ export class MxGraphShapeSelectorService {
     selectedElementCells.forEach((cell: mxgraph.mxCell) => {
       withExternalSelectedElementCells.push(cell);
       const modelElement = MxGraphHelper.getModelElement(cell);
+      if (!modelElement) {
+        return;
+      }
       if (this.loadedFiles.isElementExtern(modelElement)) {
         withExternalSelectedElementCells = [
           ...withExternalSelectedElementCells,


### PR DESCRIPTION
## Description

Fixed: 

- Information inside shapes is not rendered on creation
- On plus button, abstract properties are created with with characteristics
- Elements won't keep track of naming especially on trait creation and/or modification, on it or its children
- Plus button from trait creates no characteristic or doesn't create constraints
- duplicate elements on drag and drop from sidebar
- removing multiple elements will lead to errors
- naming issues on plus button (the numbers were not created in order or were created randomly)
- constraint creation is duplicated
- constraint search is not working in workspace for files with standalone characteristics
- fixed `new-elements.cy.ts`
